### PR TITLE
Fix Wolf UI split-mode API access and layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@ ARG GODOT_VERSION=4.4.1
 ##################### build wolf-ui ###########################################################
 ###############################################################################################
 # hadolint ignore=DL3006
-FROM ubuntu:24.10 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS builder
 ARG GODOT_VERSION
 
 RUN <<_INSTALL_DOTNET
 set -e
 
 apt-get update -y
-apt-get install -y dotnet-sdk-8.0 unzip build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev \
+apt-get install -y unzip build-essential scons pkg-config libx11-dev libxcursor-dev libxinerama-dev \
     libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libfreetype6-dev libudev-dev libxi-dev \
     libxrandr-dev yasm wget libfontconfig
 

--- a/src/Resources/WolfAPI/WolfAPI.cs
+++ b/src/Resources/WolfAPI/WolfAPI.cs
@@ -273,8 +273,12 @@ public partial class WolfApi : Resource
     {
         try
         {
-            var result = await HttpClient.GetStringAsync(url);
-            Logger.LogDebug("API call GET: {0} - {1}", url, result);
+            var resolvedUrl = url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                              url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+                ? url
+                : $"{Api}{url}";
+            var result = await HttpClient.GetStringAsync(resolvedUrl);
+            Logger.LogDebug("API call GET: {0} - {1}", resolvedUrl, result);
             var data = JsonSerializer.Deserialize<T>(result, JsonOptions);
             if (data is not null) return data;
             Logger.LogError("Could not Deserialize {0} to {1}", result, typeof(T));

--- a/src/Resources/WolfAPI/v1/Lobbies.cs
+++ b/src/Resources/WolfAPI/v1/Lobbies.cs
@@ -20,7 +20,7 @@ public partial class WolfApi
     
     public static async Task<List<Lobby>> GetLobbies()
     {
-        var lobbies = await GetAsync<LobbiesResponse>("http://localhost/api/v1/lobbies");
+        var lobbies = await GetAsync<LobbiesResponse>("/lobbies");
         if (lobbies is null) return [];
         if (lobbies.Success) return lobbies.Lobbies ?? [];
         return [];
@@ -59,10 +59,10 @@ public partial class WolfApi
              "lobby_id": "{{lobbyId}}",
              "moonlight_session_id": "{{sessionId}}"
          }
-         """;
+        """;
 
         StringContent content = new(json);
-        var result = await HttpClient.PostAsync("http://localhost/api/v1/lobbies/leave", content);
+        var result = await HttpClient.PostAsync($"{Api}/lobbies/leave", content);
         Logger.LogInformation("{0}", await result.Content.ReadAsStringAsync());
     }
     

--- a/src/Resources/WolfAPI/v1/Sessions.cs
+++ b/src/Resources/WolfAPI/v1/Sessions.cs
@@ -9,7 +9,7 @@ public partial class WolfApi
 {
     public static async Task<Session?> GetSession()
     {
-        var sessions = await WolfApi.GetAsync<SessionsResponse>("http://localhost/api/v1/sessions");
+        var sessions = await WolfApi.GetAsync<SessionsResponse>("/sessions");
         if (sessions?.Sessions is null) return null;
         var currSession = sessions.Sessions.FirstOrDefault(session => session.ClientId == SessionId);
         if (currSession is not null) return currSession;
@@ -27,7 +27,7 @@ public partial class WolfApi
     
     public static async void StopSession(string sessionId)
     {
-        var url = "http://localhost/api/v1/session/stop";
+        var url = "/session/stop";
         try
         {
             var data = $$"""
@@ -37,7 +37,7 @@ public partial class WolfApi
                          """;
             Logger.LogDebug("API call POST: {0} - {1}", url, data);
             StringContent content = new(data);
-            var result = await HttpClient.PostAsync(url, content);
+            var result = await HttpClient.PostAsync($"{Api}{url}", content);
             var returnData = await result.Content.ReadAsStringAsync();
             Logger.LogDebug("API answer from: {0} - {1}", url, returnData);
         }

--- a/src/Resources/WolfAPI/v1/Utils.cs
+++ b/src/Resources/WolfAPI/v1/Utils.cs
@@ -56,7 +56,7 @@ public partial class WolfApi
         HttpResponseMessage message;
         try
         {
-            message = await HttpClient.GetAsync($"http://localhost/api/v1/utils/get-icon?icon_path={iconPath}");
+            message = await HttpClient.GetAsync($"{Api}/utils/get-icon?icon_path={iconPath}");
         }
         catch (HttpRequestException e)
         {

--- a/src/project.godot
+++ b/src/project.godot
@@ -25,6 +25,7 @@ window/size/viewport_width=1280
 window/size/viewport_height=720
 window/size/always_on_top=true
 window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
 display_server/driver.linuxbsd="wayland"
 
 [dotnet]


### PR DESCRIPTION
## What changed
This fixes Wolf UI's in-container API access and split-mode layout behavior.

- The API client no longer assumes `http://localhost/...` and instead uses the mounted Wolf socket path correctly inside the container.
- The Dockerfile is updated to build cleanly again on a current Ubuntu base.
- The Godot stretch configuration is adjusted so split-mode seats fill the available render area correctly.

## Why
Party mode was blocked by two separate Wolf UI issues during live validation:

- the app tried to reach the Wolf API over `localhost:80` instead of the mounted socket-backed path
- the split layout stayed vertically compressed because the project stretch settings were too restrictive for the narrower render target

## Impact
Wolf UI can launch inside a party-mode seat, talk to the local Wolf API correctly, and render into the split viewport without the half-height layout issue.

## Validation
- `docker build -t wolf-ui:local /home/virant/gow/wolf-ui`
- live validation through Wolf party mode on a Moonlight session
