### PR TITLE
feat: added Env var to allow changing Wolf-UI startup parameter. closes #14

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,25 @@
 # Wolf-UI
 A UI for Wolf, the main entrypoint when starting a streaming session 
 
-Special thanks to: 
+----
+### Supported Environment Args
+- WOLF_UI_ARGS 
+
+Append arguments to the Wolf-UI launch command.
+To force Wolf-UI to use the OpenGl3 backend use `WOLF_UI_ARGS=--rendering-method gl_compatibility --rendering-driver opengl3`
+
+- WOLF_SOCKET_PATH 
+
+Set the path where Wolf-UI will look for the socket
+
+- LOGLEVEL
+
+Set the loglevel, valid arguments: `NONE` `ERROR` `WARNING` `WARN` `INFORMATION` `INFO` `DEBUG`
+
+- WOLF_UI_AUTOUPDATE
+
+if set to `True` then Wolf-UI will ask for a pull of the latest Wolf-UI image on start. Still WIP for none stable releases
+
+---
+### Special thanks to: 
 - [THOSE AWESOME GUYS](https://thoseawesomeguys.com/) for their awsome [icon pack](https://thoseawesomeguys.com/prompts/)

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -13,4 +13,5 @@ done
 
 gow_log "Starting Wolf-UI"
 source /opt/gow/launch-comp.sh
-launcher wolf-ui -f -t
+opts=( $WOLF_UI_ARGS )
+launcher wolf-ui -f -t "${opts[@]}"


### PR DESCRIPTION
Vulcan Forward+ seems to make problems for some users, this pr adds a Env Var that allows appending arguments to the start command of Wolf-UI allowing to change the render backend.
Adding:

`WOLF_UI_ARGS=--rendering-method gl_compatibility --rendering-driver opengl3`

to the Wolf-UI env array in the config will switch the renderer to OpenGL3 and disable Forward+.

fix for #14 